### PR TITLE
Guard bindings.gyp and build dummy when not on IBM i

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,6 +9,7 @@
             },
             'conditions': [
               [ '"<(os_name)"=="OS400"', {
+                # Here we know we are really on IBM i
                 'include_dirs': [
                   'src/db2ia',
                   '/usr/include',
@@ -43,6 +44,12 @@
             ]
         }],
       ],
+      # When not on IBM i the following builds the dummy package
+      # os: property in package.json should prevent us from building this dummy
+      # unless when really on AIX or os is being ignored by npm bug
+      # https://github.com/silverwind/default-gateway/issues/10
+      # https://npm.community/t/npm-ci-ignores-the-os-field-of-package-json/5607
+
       'include_dirs': [
         'src/db2ia',
         "<!@(node -p \"require('node-addon-api').include\")"

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,36 +2,57 @@
   'targets': [
     {
       'target_name': 'db2ia',
+      "conditions": [
+        ['OS=="aix"', {
+          'variables': {
+              'os_name': '<!(uname -s)',
+            },
+            'conditions': [
+              [ '"<(os_name)"=="OS400"', {
+                'include_dirs': [
+                  'src/db2ia',
+                  '/usr/include',
+                  "<!@(node -p \"require('node-addon-api').include\")"
+                ],
+                'sources': [ 
+                  'src/db2ia/db2ia.cc', 
+                  'src/db2ia/dbconn.cc',
+                  'src/db2ia/dbstmt.cc'
+                ],
+                'cflags': [
+                  '-std=c++0x',
+                  '-Wno-unknown-pragmas',
+                  '-Wno-format',
+                  '-gxcoff',
+                  '-O0',
+                  '-DNAPI_DISABLE_CPP_EXCEPTIONS',
+                  '-I/QOpenSys/pkgs/include'
+                ],
+                'ldflags': [ 
+                  '-Wl,-bbigtoc', 
+                  '-Wl,-brtl', 
+                  '-Wl,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib:/opt/freeware/lib'
+                ],
+                'link_settings': {
+                  'libraries': [
+                    '-L/QOpenSys/pkgs/lib:/QOpenSys/usr/lib:/opt/freeware/lib',
+                    '-ldb400'
+                  ],
+                }
+              }],
+            ]
+        }],
+      ],
       'include_dirs': [
         'src/db2ia',
-        '/usr/include',
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       'sources': [ 
-        'src/db2ia/db2ia.cc', 
-        'src/db2ia/dbconn.cc',
-        'src/db2ia/dbstmt.cc'
+        'src/db2ia/db2ia.cc',
       ],
-      'cflags': [
-        '-std=c++0x',
-        '-Wno-unknown-pragmas',
-        '-Wno-format',
-        '-gxcoff',
-        '-O0',
-        '-DNAPI_DISABLE_CPP_EXCEPTIONS',
-        '-I/QOpenSys/pkgs/include'
-      ],
-      'ldflags': [ 
-        '-Wl,-bbigtoc', 
-        '-Wl,-brtl', 
-        '-Wl,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib:/opt/freeware/lib'
-      ],
-      'link_settings': {
-        'libraries': [
-          '-L/QOpenSys/pkgs/lib:/QOpenSys/usr/lib:/opt/freeware/lib',
-          '-ldb400'
+      'defines': [
+          'NAPI_DISABLE_CPP_EXCEPTIONS',
         ],
-      }
     },
     {
       "target_name": "action_after_build",

--- a/src/db2ia/db2ia.cc
+++ b/src/db2ia/db2ia.cc
@@ -3,13 +3,19 @@
  *  deposited with the U.S. Copyright Office.                        
 */ 
 
-#include "dbconn.h"
-#include "dbstmt.h"
 #include <napi.h>
 
+#ifdef __PASE__
+
+#include "dbconn.h"
+#include "dbstmt.h"
 SQLHENV envh;
 
+#endif
+
+
 Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
+  #ifdef __PASE__
   int param = SQL_TRUE;
   char *attr = (char *)"DB2CCSID", *ccsid = NULL;
   ccsid = getenv(attr);
@@ -43,7 +49,9 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
   
   DbConn::Init(env, exports, envh);
   DbStmt::Init(env, exports);
+  #endif
   
+  // when not on PASE return a dummy object
   return exports;
 }
 


### PR DESCRIPTION
This PR is related  to issue #54 

Most of the time NPM will block installs on systems where process.platform does not return AIX

According to this [issue](https://npm.community/t/npm-ci-ignores-the-os-field-of-package-json/5607) there are strange cases with npm-ci, where `os` property within [package.json](https://github.com/IBM/nodejs-idb-connector/blob/master/package.json#L5) is ignored. This issue originally popped on this [issue](https://github.com/silverwind/default-gateway/issues/10) with default-gateway package.

In this PR we guard against weird cases when `os` is ignored by adding conditionals in `bindings.gyp` and `db2ia.cc`. When not on IBM i a dummy package is created returning an empty object. This includes when really on AIX and not on IBM i.

