### PR TITLE
update binding.gyp (#65)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -27,7 +27,8 @@
                   '-gxcoff',
                   '-O0',
                   '-DNAPI_DISABLE_CPP_EXCEPTIONS',
-                  '-I/QOpenSys/pkgs/include'
+                  '-I/QOpenSys/pkgs/include',
+                  '-I/QOpenSys/pkgs/include/cli'
                 ],
                 'ldflags': [ 
                   '-Wl,-bbigtoc', 


### PR DESCRIPTION
add a searching path /QOpenSys/pkgs/include/cli for 
sqlcli headers delivered via rpm.