### PR TITLE
[dbstmt] retrieve data when SQLFetch return SQL_SUCCESS_WITH_INFO

### DIFF
--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -1160,7 +1160,7 @@ Napi::Value DbStmt::FetchSync(const Napi::CallbackInfo& info) {
   sqlReturnCode = SQLFetch(this->stmth);
   DEBUG(this, "SQLFetch(%d).\n", sqlReturnCode);
 
-  if(sqlReturnCode == SQL_SUCCESS)
+  if(sqlReturnCode == SQL_SUCCESS || sqlReturnCode == SQL_SUCCESS_WITH_INFO)
   {
     Napi::Object row = Napi::Object::New(env);
     this->fetch(env, &row);
@@ -1971,8 +1971,11 @@ int DbStmt::populateColumnDescriptions(Napi::Env env) {
   
     SQLRETURN sqlReturnCode;
     // Doc https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_73/cli/rzadpfnfetch.htm
-    while(( sqlReturnCode = SQLFetch(stmth)) == SQL_SUCCESS) 
+    while(true) 
     {
+      sqlReturnCode = SQLFetch(stmth);
+      if(sqlReturnCode != SQL_SUCCESS && sqlReturnCode != SQL_SUCCESS_WITH_INFO)
+        break;
       result_item* row = (result_item*)calloc(colCount, sizeof(result_item)); 
       for(int i = 0; i < colCount; i++)
       {


### PR DESCRIPTION
Signed-off-by: mengxumx <mengxumx@cn.ibm.com>

Related issue: #68 @jasonclake 

- If `SQLExecDirect()` return `SQL_SUCCESS_WITH_INFO`, it means the data is not in the query result set, we need to `fetch` it by ourselves.
- If `SQLFetch()` return `SQL_SUCCESS_WITH_INFO`, currently I just treat it the same as `SQL_SUCCESS` and retrieve the data directly.

Test result seems OK --
```
-bash-4.4$ node idb-fetch-withinfo.js
This works---------------------------------------------
sql: select name
    , sum(case hasSpecAttr when '1' then 1 else 0 end) cnt
    from xumeng.article
    group by name
result: [
  {
    "NAME": "Article1            ",
    "CNT": "1"
  }
]
error: null
This does NOT work---------------------------------------------
sql: select name
    , count(case hasSpecAttr when '1' then 1 else null end) cnt
    from xumeng.article
    group by name
result: [
  {
    "NAME": "Article1            ",
    "CNT": "1"
  }
]
error: null
```