### PR TITLE
Making sure data remains until Buffer is deleted in JS environment

### DIFF
--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2081,7 +2081,7 @@ int DbStmt::populateColumnDescriptions(Napi::Env env) {
             {
               SQLCHAR *binaryData = new SQLCHAR[result[i][j].rlength]; // have to save the data on the heap
               memcpy((SQLCHAR *) binaryData, result[i][j].data, result[i][j].rlength);
-              value = Napi::Buffer::New(env, binaryData, result[i][j].rlength, [](Napi::Env env, void* finalizeData) {
+              value = Napi::Buffer<char>::New(env, binaryData, result[i][j].rlength, [](Napi::Env env, void* finalizeData) {
                 delete[] (SQLCHAR*)finalizeData;
               });
               break;

--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2078,8 +2078,14 @@ int DbStmt::populateColumnDescriptions(Napi::Env env) {
             case SQL_VARBINARY :
             case SQL_BINARY : 
             case SQL_BLOB :
-              value = Napi::Buffer<char>::New(env, result[i][j].data, result[i][j].rlength);
+            {
+              SQLCHAR *binaryData = new SQLCHAR[result[i][j].rlength]; // have to save the data on the heap
+              memcpy((SQLCHAR *) binaryData, result[i][j].data, result[i][j].rlength);
+              value = Napi::Buffer::New(env, binaryData, result[i][j].rlength, [](Napi::Env env, void* finalizeData) {
+                delete[] (SQLCHAR*)finalizeData;
+              });
               break;
+            }
             case SQL_SMALLINT :
             case SQL_INTEGER :
               if(asNumber == true){

--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2081,7 +2081,7 @@ int DbStmt::populateColumnDescriptions(Napi::Env env) {
             {
               SQLCHAR *binaryData = new SQLCHAR[result[i][j].rlength]; // have to save the data on the heap
               memcpy((SQLCHAR *) binaryData, result[i][j].data, result[i][j].rlength);
-              value = Napi::Buffer<char>::New(env, binaryData, result[i][j].rlength, [](Napi::Env env, void* finalizeData) {
+              value = Napi::Buffer<SQLCHAR>::New(env, binaryData, result[i][j].rlength, [](Napi::Env env, void* finalizeData) {
                 delete[] (SQLCHAR*)finalizeData;
               });
               break;


### PR DESCRIPTION
The data stored in the Buffer is freed, but we want to retain that data until the Buffer no longer has any references. Copy the data to a new array of data, then pass a Finalizer function to the Buffer, which will run when the Buffer is deleted to also delete the underlying data.

Fixes #86 