### PR TITLE
ci: Update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,16 +14,31 @@ Please fill in as much of the template below as you can.
 
 Node.js version: output of `node -v`
 idb-connector version: output of `npm ls idb-connector`
-Platform: output of `uname -a`
+IBM i version: output of `uname -vr`
 
 If possible, please provide code that demonstrates the problem, keeping it as
 simple and free of external dependencies as you can.
 
 And please provide the output with debugging messages -- `dbconn.debug(true)`
 -->
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1.
+2. 
+3.
+4. 
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
 
 * **Node.js version**:
 * **idb-connector version**:
-* **Operating System**:
+* **IBM i version:**:
 
 <!-- Please provide more details below this comment. -->


### PR DESCRIPTION
Use IBM i version instead of Platform / OS since idb-connector is only supported on IBM i.

Also suggest `uname -vr` because `uname -a` will output additional information like `-n, --nodename           print the network node hostname` that we might not want.

Also add Headers to Describe the bug, Steps to reproduce, Expected behavior, and Screenshots.

Resolves #100 
