### PR TITLE
ci: Use the enhancement label for the feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: feature
+labels: enhancement
 assignees: ''
 
 ---


### PR DESCRIPTION
The `feature` label does not exist. We do have the `enhancement` label which is used for new features and requests. We should default to use it instead.