### PR TITLE
add a new API fieldInfo (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # idb-connector changelog
+## 1.2.9
+- [dbstmt] add a new API fieldInfo ( #115 )
+
 ## 1.2.8
 - [dbstmt] fix: select-insert when binding strings ( #114 )
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@
   - [dbstmt.fieldName(index)](#dbstmtfieldnameindex)
   - [dbstmt.fieldPrecise(index)](#dbstmtfieldpreciseindex)
   - [dbstmt.fieldScale(index)](#dbstmtfieldscaleindex)
+  - [dbstmt.fieldInfo(index)](#dbstmtfieldinfoindex)
   - [dbstmt.stmtError(callback)](#dbstmtstmterrorcallback)
   - [dbstmt.asNumber(flag)](#dbstmtasnumberflag)
 
@@ -1451,6 +1452,35 @@ fieldScale(index)
 **Returns:**
 
 `number(integer)` indicating the scale of the specified column in the result set.
+
+**DB2 CLI API:** SQLColAttribute
+
+**Valid Scope:** When the result set is available.
+___
+
+### dbstmt.fieldInfo(index)
+**Description:**
+
+If a valid index is provided, `fieldInfo` returns the information of the indicated column.
+
+**Syntax:**
+
+fieldInfo(index)
+
+**Parameters:**
+
+- **index:** `number(integer)` the column number in a result set, ordered sequentially left to right, starting at 0.
+
+**Returns:**
+
+An `object` indicating the information of the specified column in the result set. It contains following fields:
+- `Name(string)` indicating the name of the specified column in the result set.
+- `Type(number)` indicating the data type of the specified column in the result set.
+- `TypeName(string)` indicating the data type name of the specified column in the result set.
+- `Width(number)` indicating the width of the specified column in the result set.
+- `Precise(number)` indicating the precision of the specified column in the result set.
+- `Scale(number)` indicating the scale of the specified column in the result set.
+- `Nullable(boolean)` indicating if the column can be set to NULL.
 
 **DB2 CLI API:** SQLColAttribute
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idb-connector",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "A Node.js DB2 driver for IBM i",
   "os": [
     "aix"

--- a/src/db2ia/dberror.h
+++ b/src/db2ia/dberror.h
@@ -104,65 +104,67 @@ static const char* getSQLType(int sqlType)
 {
     switch (sqlType)
     {
-    case SQL_CHAR:
+    case SQL_CHAR:          // SQL_CHAR(SQL_CODE_DATE) = 1
         return "CHAR";
-    case SQL_NUMERIC:
+    case SQL_NUMERIC:       // SQL_NUMERIC(SQL_CODE_TIME) = 2
         return "NUMERIC";
-    case SQL_DECIMAL:
+    case SQL_DECIMAL:       // SQL_DECIMAL(SQL_CODE_TIMESTAMP) = 3
         return "DECIMAL";
-    case SQL_INTEGER:
+    case SQL_INTEGER:       // SQL_INTEGER = 4
         return "INTEGER";
-    case SQL_SMALLINT:
+    case SQL_SMALLINT:      // SQL_SMALLINT = 5
         return "SMALLINT";
-    case SQL_FLOAT:
+    case SQL_FLOAT:         // SQL_FLOAT = 6
         return "FLOAT";
-    case SQL_REAL:
+    case SQL_REAL:          // SQL_REAL = 7
         return "REAL";
-    case SQL_DOUBLE:
+    case SQL_DOUBLE:        // SQL_DOUBLE = 8
         return "DOUBLE";
-    case SQL_DATETIME:
+    case SQL_DATETIME:      // SQL_DATETIME = 9
         return "DATETIME";
-    case SQL_VARCHAR:
+    case SQL_VARCHAR:       // SQL_VARCHAR(SQL_LONGVARCHAR) = 12
         return "VARCHAR";
-    case SQL_BLOB:
+    case SQL_BLOB:          // SQL_BLOB = 13
         return "BLOB";
-    case SQL_CLOB:
+    case SQL_CLOB:          // SQL_CLOB = 14
         return "CLOB";
-    case SQL_DBCLOB:
+    case SQL_DBCLOB:        // SQL_DBCLOB = 15
         return "DBCLOB";
-    case SQL_DATALINK:
+    case SQL_DATALINK:      // SQL_DATALINK = 16
         return "DATALINK";
-    case SQL_WCHAR:
+    case SQL_WCHAR:         // SQL_WCHAR = 17
         return "WCHAR";
-    case SQL_WVARCHAR:
+    case SQL_WVARCHAR:      // SQL_WVARCHAR(SQL_WLONGVARCHAR) = 18
         return "WVARCHAR";
-    case SQL_BIGINT:
+    case SQL_BIGINT:        // SQL_BIGINT = 19
         return "BIGINT";
-    case SQL_BLOB_LOCATOR:
+    case SQL_BLOB_LOCATOR:  // SQL_BLOB_LOCATOR = 20
         return "BLOB_LOCATOR";
-    case SQL_CLOB_LOCATOR:
+    case SQL_CLOB_LOCATOR:  // SQL_CLOB_LOCATOR = 21
         return "CLOB_LOCATOR";
-    case SQL_DBCLOB_LOCATOR:
+    case SQL_DBCLOB_LOCATOR:// SQL_DBCLOB_LOCATOR = 22
         return "DBCLOB_LOCATOR";
-    case SQL_UTF8_CHAR:
+    case SQL_UTF8_CHAR:     // SQL_UTF8_CHAR = 23
         return "UTF8_CHAR";
-    case SQL_GRAPHIC:
+    case SQL_GRAPHIC:       // SQL_GRAPHIC = 95
         return "GRAPHIC";
-    case SQL_BINARY:
+    case SQL_VARGRAPHIC:    // SQL_VARGRAPHIC(SQL_LONGVARGRAPHIC) = 96
+        return "VARGRAPHIC";
+    case SQL_BINARY:        // SQL_BINARY = -2
         return "BINARY";
-    case SQL_VARBINARY:
+    case SQL_VARBINARY:     // SQL_VARBINARY(SQL_LONGVARBINARY) = -3
         return "VARBINARY";
-    case SQL_DATE:
+    case SQL_DATE:          // SQL_DATE(SQL_TYPE_DATE) = 91
         return "DATE";
-    case SQL_TIME:
+    case SQL_TIME:          // SQL_TIME(SQL_TYPE_TIME) = 92
         return "TIME";
-    case SQL_TIMESTAMP:
+    case SQL_TIMESTAMP:     // SQL_TIMESTAMP(SQL_TYPE_TIMESTAMP) = 93
         return "TIMESTAMP";
-    case SQL_ALL_TYPES:
+    case SQL_ALL_TYPES:     // SQL_ALL_TYPES = 0
         return "ALL_TYPES";
-    case SQL_DECFLOAT:
+    case SQL_DECFLOAT:      // SQL_DECFLOAT = -360
         return "DECFLOAT";
-    case SQL_XML:
+    case SQL_XML:           // SQL_XML = -370
         return "XML";
     default:
         return "UNKNOWN";

--- a/src/db2ia/dbstmt.h
+++ b/src/db2ia/dbstmt.h
@@ -97,6 +97,7 @@ private:
   Napi::Value FieldPrecise(const Napi::CallbackInfo &info);
   Napi::Value FieldScale(const Napi::CallbackInfo &info);
   Napi::Value FieldNullable(const Napi::CallbackInfo &info);
+  Napi::Value FieldInfo(const Napi::CallbackInfo &info);
 
   Napi::Value AsNumber(const Napi::CallbackInfo &info);
 

--- a/test/statementTest.js
+++ b/test/statementTest.js
@@ -297,6 +297,49 @@ describe('Statement Misc Test', () => {
   });
 
 
+  describe('fieldInfo', () => {
+    it('requires an int index parameter, returns the information of the indicated column', (done) => {
+      const sql = 'SELECT * FROM QIWS.QCUSTCDT';
+
+      dbStmt.prepare(sql, (error) => {
+        if (error) {
+          throw error;
+        }
+        dbStmt.execute((out, error) => {
+          if (error) {
+            throw error;
+          }
+          const col1 = dbStmt.fieldInfo(0);
+          const col2 = dbStmt.fieldInfo(1);
+          expect(col1).to.be.a('object');
+          expect(col2).to.be.a('object');
+          // console.log(JSON.stringify(col1, '', 2));
+          // console.log(JSON.stringify(col2, '', 2));
+          expect(col1).to.eql({
+            "Name": "CUSNUM",
+            "Type": 2,
+            "TypeName": "NUMERIC",
+            "Width": 7,
+            "Precise": 6,
+            "Scale": 0,
+            "Nullable": false
+          });
+          expect(col2).to.eql({
+            "Name": "LSTNAM",
+            "Type": 1,
+            "TypeName": "CHAR",
+            "Width": 7,
+            "Precise": 8,
+            "Scale": 0,
+            "Nullable": false
+          });
+          done();
+        });
+      });
+    });
+  });
+
+
   describe('stmtError', () => {
     it('Returns the diagnostic information ', (done) => {
       const sql = 'SELECT * FROM NOT.THERE';


### PR DESCRIPTION
The new API fieldInfo provides all the information returned from filedName, filedType, filedWidth, filedPrecise, filedScale and filedNullable.

And the new **TypeName** property now returns data type as **STRING** per this requirement ( #115 ).

An example of the returned object is --
```
{
  "Name": "CUSNUM",
  "Type": 2,
  "TypeName": "NUMERIC",
  "Width": 7,
  "Precise": 6,
  "Scale": 0,
  "Nullable": false
}
```