### PR TITLE
fix: UTF-8 data not properly formed error

### DIFF
--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2589,7 +2589,7 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
       if (bindIndicator == 0 || bindIndicator == 1)
       { //Parameter is string or clob
         std::string string = value.ToString().Utf8Value();
-        int str_length = string.length();
+        size_t str_length = string.length();
         const char *cString = string.c_str();
         param[i].valueType = SQL_C_CHAR;
 

--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2593,7 +2593,7 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
         const char *cString = string.c_str();
         param[i].valueType = SQL_C_CHAR;
 
-        if (param[i].io == SQL_PARAM_INPUT)
+        if (param[i].io == SQL_PARAM_INPUT || param[i].io == SQL_PARAM_INPUT_OUTPUT)
         {
           param[i].buf = strdup(cString);
           param[i].ind = str_length;
@@ -2602,15 +2602,6 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
         {
           param[i].buf = (char *)calloc(param[i].paramSize + 1, sizeof(char));
           param[i].ind = param[i].paramSize;
-        }
-        else if (param[i].io == SQL_PARAM_INPUT_OUTPUT)
-        {
-          param[i].buf = (char *)calloc(param[i].paramSize + 1, sizeof(char));
-          strncpy((char *)param[i].buf, cString, str_length);
-          if (bindIndicator == 0) //CLOB
-            param[i].ind = str_length;
-          else if (bindIndicator == 1) //NTS
-            param[i].ind = SQL_NTS;
         }
       }
       else if (bindIndicator == 2)
@@ -2762,16 +2753,20 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
       default: // SQL_CHAR / SQL_VARCHAR / SQL_WCHAR / SQL_WVARCHAR
       {
         param[i].valueType = SQL_C_CHAR;
-        param[i].ind = SQL_NTS;
-        param[i].buf = (char *)calloc(param[i].paramSize + 1, sizeof(char));
+
         if(value.IsString())
         {
           std::string string = value.ToString().Utf8Value();
+          size_t str_length = string.length();
           const char *cString = string.c_str();
-          if(strlen(cString) > 0) {
-            strcpy((char *)param[i].buf, cString);
-            param[i].ind = strlen(cString);
-          }
+
+          param[i].buf = strdup(cString);
+          param[i].ind = str_length;
+        }
+        else
+        {
+          param[i].ind = SQL_NTS;
+          param[i].buf = (char *)calloc(param[i].paramSize + 1, sizeof(char));
         }
       }
       break;

--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2589,18 +2589,14 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
       if (bindIndicator == 0 || bindIndicator == 1)
       { //Parameter is string or clob
         std::string string = value.ToString().Utf8Value();
+        int str_length = string.length();
         const char *cString = string.c_str();
-        int str_length = strlen(cString);
-        if (str_length > param[i].paramSize)
-          str_length = param[i].paramSize;
         param[i].valueType = SQL_C_CHAR;
+
         if (param[i].io == SQL_PARAM_INPUT)
         {
-          param[i].buf = strndup(cString, str_length);
-          if (bindIndicator == 0) //CLOB
-            param[i].ind = str_length;
-          else if (bindIndicator == 1) //NTS
-            param[i].ind = SQL_NTS;
+          param[i].buf = strdup(cString);
+          param[i].ind = str_length;
         }
         else if (param[i].io == SQL_PARAM_OUTPUT)
         {


### PR DESCRIPTION
Error originates in bindParams() where the indicator/strlen was being set to
SQL_NTS instead of the length of input. Therefore the entire string was
not being passed causing malformed UTF-8 data.

This is still a WIP given that areas other than if the parameter io is `SQL_PARAM_INPUT` may also need to get fixed too.

Fixes #129 