### PR TITLE
fix: Check for Javascript empty-string in `bindParameters`

### DIFF
--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2776,9 +2776,14 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
           std::string string = value.ToString().Utf8Value();
           size_t str_length = string.length();
           const char *cString = string.c_str();
-
+          
+          if (cString[0] == '\0') // Check for JS empty-string.
+           {
+            param[i].ind = SQL_NTS;
+          } else {
+            param[i].ind = str_length;
+          }
           param[i].buf = strdup(cString);
-          param[i].ind = str_length;
         }
         else
         {

--- a/test/asyncStatementTest.js
+++ b/test/asyncStatementTest.js
@@ -147,6 +147,60 @@ describe('Statement Async Test', () => {
                 });
             });
           });
+        })
+      });
+    });
+    it("should insert spaces into CHAR columns when given a Javascript empty-string.", done => {
+      const sql = `
+      INSERT INTO QIWS.QCUSTCDT (
+        CUSNUM,LSTNAM,INIT,STREET,CITY,STATE,ZIPCOD,CDTLMT,CHGCOD,BALDUE,CDTDUE
+        )
+      VALUES (?,?,?,?,?,?,?,?,?,?,?) with NONE `;
+      const dbConn2 = new dbconn();
+      dbConn2.conn("*LOCAL");
+      const dbStmt2 = new dbstmt(dbConn2);
+      const params = [
+        9998,
+        "",
+        "",
+        "123 Broadway",
+        "Hope",
+        "WA",
+        98101,
+        2000,
+        1,
+        250,
+        0.0,
+      ];
+      dbStmt2.prepare(sql, error => {
+        if (error) {
+          throw error;
+        }
+        dbStmt2.bindParameters(params, error => {
+          if (error) {
+            throw error;
+          }
+          expect(error).to.be.null;
+          dbStmt2.execute((out, error) => {
+            if (error) {
+              throw error;
+            }
+            expect(error).to.be.null;
+            dbStmt2.close();
+            dbStmt = new dbstmt(dbConn);
+            dbStmt.exec(
+              "SELECT q.*, hex(lstnam) AS hexlstnam FROM QIWS.QCUSTCDT q where q.lstnam = '        '",
+              (result, error) => {
+                if (error) {
+                  throw error;
+                }
+                const rowsSelected = Number(result.length);
+
+                expect(rowsSelected).to.equal(1);
+                done();
+              } // }4040404040404040
+            );
+          });
         });
       });
     });


### PR DESCRIPTION
When trying to insert a JS empty string `""` into a `CHAR` field via a dynamic prepared statement, the error is thrown: `SQLSTATE=22504 SQLCODE=-191 Mixed data or UTF-8 data not properly formed.`
Currently, on driver version 1.2.13, this can be replicated by running the test added in this pull request in `test/asyncStatementTest.js`.

This fix allows empty strings to be used as `CHAR` values by specifying their length as `SQL_NTS` rather than checking their actual length, which is `0`.