### PR TITLE
Fix EBADPLATFORM build error on Node 18 / Python 3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "Mark Irish <mirish@ibm.com> (https://github.com/markdirish)"
   ],
   "os": [
+    "os400",
     "aix"
   ],
   "gypfile": true,


### PR DESCRIPTION
Because we had only aix listed as a valid OS, we get an error building
with Python 3.9 on Node 18 since it reports correctly as os400 now:

npm ERR! notsup Valid OS:    aix
npm ERR! notsup Valid Arch:  undefined
npm ERR! notsup Actual OS:   os400
npm ERR! notsup Actual Arch: ppc64

Once we no longer support Node 16, we can remove aix from this list as
well.