### PR TITLE
fix: Binding parameters issues

### DIFF
--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2778,7 +2778,7 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
           const char *cString = string.c_str();
           // CLI does not honor the buffer size parameter or the output size in the indicator
           // Make the buffer size is at least the size of parameter or the size of the string
-          param[i].buf = (char *)calloc(std::max(static_cast<size_t>(param[i].paramSize), str_length) +1, sizeof(char));
+          param[i].buf = (char *)calloc(std::max(static_cast<size_t>(param[i].paramSize), str_length) + 1, sizeof(char));
           // set the indicator to be SQL_NTS
           // this helps in edge cases like empty string where indicator is set 0 (which CLI doesn't like for some reason)
           param[i].ind = SQL_NTS;

--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2611,9 +2611,9 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
         param[i].valueType = SQL_C_CHAR;
         // CLI does not honor the buffer size parameter or the output size in the indicator
         // Make the buffer size is at least the size of parameter or the size of the string
-        param[i].buf = (char *)calloc(std::max(static_cast<size_t>(param[i].paramSize) + 1, str_length), sizeof(char));
+        param[i].buf = (char *)calloc(std::max(static_cast<size_t>(param[i].paramSize), str_length) + 1, sizeof(char));
         // Set the indicator to be SQL_NTS
-        // this helps in edge cases like empty string where indicator is set 0
+        // this helps in edge cases like empty string where indicator is set 0 (which CLI doesn't like for some reason)
         param[i].ind = SQL_NTS;
         if (param[i].io != SQL_PARAM_OUTPUT) {
             // for SQL_PARAM_INPUT and SQL_PARAM_INPUT_OUTPUT
@@ -2778,9 +2778,9 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
           const char *cString = string.c_str();
           // CLI does not honor the buffer size parameter or the output size in the indicator
           // Make the buffer size is at least the size of parameter or the size of the string
-          param[i].buf = (char *)calloc(std::max(static_cast<size_t>(param[i].paramSize) + 1, str_length), sizeof(char));
+          param[i].buf = (char *)calloc(std::max(static_cast<size_t>(param[i].paramSize), str_length) +1, sizeof(char));
           // set the indicator to be SQL_NTS
-          // this helps in edge cases like empty string where indicator is set 0
+          // this helps in edge cases like empty string where indicator is set 0 (which CLI doesn't like for some reason)
           param[i].ind = SQL_NTS;
           // SQL_PARAM_INPUT_OUTPUT is always set so
           // copy the string to the buffer

--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2610,7 +2610,8 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
         const char *cString = string.c_str();
         param[i].valueType = SQL_C_CHAR;
         // CLI does not honor the buffer size parameter or the output size in the indicator
-        // Make the buffer size is at least the size of parameter or the size of the string
+        // Ensure the buffer size is at least the size of parameter or the size of the string
+
         param[i].buf = (char *)calloc(std::max(static_cast<size_t>(param[i].paramSize), str_length) + 1, sizeof(char));
         // Set the indicator to be SQL_NTS
         // this helps in edge cases like empty string where indicator is set 0 (which CLI doesn't like for some reason)

--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2777,7 +2777,8 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
           size_t str_length = string.length();
           const char *cString = string.c_str();
           // CLI does not honor the buffer size parameter or the output size in the indicator
-          // Make the buffer size is at least the size of parameter or the size of the string
+          // Ensure the buffer size is at least the size of parameter or the size of the string
+
           param[i].buf = (char *)calloc(std::max(static_cast<size_t>(param[i].paramSize), str_length) + 1, sizeof(char));
           // set the indicator to be SQL_NTS
           // this helps in edge cases like empty string where indicator is set 0 (which CLI doesn't like for some reason)

--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2609,16 +2609,16 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
         size_t str_length = string.length();
         const char *cString = string.c_str();
         param[i].valueType = SQL_C_CHAR;
-
-        if (param[i].io == SQL_PARAM_INPUT || param[i].io == SQL_PARAM_INPUT_OUTPUT)
-        {
-          param[i].buf = strdup(cString);
-          param[i].ind = str_length;
-        }
-        else if (param[i].io == SQL_PARAM_OUTPUT)
-        {
-          param[i].buf = (char *)calloc(param[i].paramSize + 1, sizeof(char));
-          param[i].ind = param[i].paramSize;
+        // CLI does not honor the buffer size parameter or the output size in the indicator
+        // Make the buffer size is at least the size of parameter or the size of the string
+        param[i].buf = (char *)calloc(std::max(static_cast<size_t>(param[i].paramSize) + 1, str_length), sizeof(char));
+        // Set the indicator to be SQL_NTS
+        // this helps in edge cases like empty string where indicator is set 0
+        param[i].ind = SQL_NTS;
+        if (param[i].io != SQL_PARAM_OUTPUT) {
+            // for SQL_PARAM_INPUT and SQL_PARAM_INPUT_OUTPUT
+            // copy the string to the buffer
+            strcpy((char*)param[i].buf, cString);
         }
       }
       else if (bindIndicator == 2)
@@ -2776,14 +2776,15 @@ int DbStmt::bindParams(Napi::Env env, Napi::Array *params, std::string &error)
           std::string string = value.ToString().Utf8Value();
           size_t str_length = string.length();
           const char *cString = string.c_str();
-          
-          if (cString[0] == '\0') // Check for JS empty-string.
-           {
-            param[i].ind = SQL_NTS;
-          } else {
-            param[i].ind = str_length;
-          }
-          param[i].buf = strdup(cString);
+          // CLI does not honor the buffer size parameter or the output size in the indicator
+          // Make the buffer size is at least the size of parameter or the size of the string
+          param[i].buf = (char *)calloc(std::max(static_cast<size_t>(param[i].paramSize) + 1, str_length), sizeof(char));
+          // set the indicator to be SQL_NTS
+          // this helps in edge cases like empty string where indicator is set 0
+          param[i].ind = SQL_NTS;
+          // SQL_PARAM_INPUT_OUTPUT is always set so
+          // copy the string to the buffer
+          strcpy((char*)param[i].buf, cString);
         }
         else
         {


### PR DESCRIPTION
Resolves https://github.com/IBM/nodejs-idb-connector/issues/147#issuecomment-1208227784

https://github.com/IBM/nodejs-idb-connector/issues/147#issuecomment-1257673673


We now set `SQL_NTS` as the indicator instead of the string length.

This helps in edge cases like empty string where indicator is set to 0. Also we now ensure the buffer size is at least the size of parameter or the size of the string.