### PR TITLE
ci: Add npm publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/README.md
+++ b/README.md
@@ -128,12 +128,10 @@ Note: sqlcli header files, GCC, and Python are required to compile the code.
    npm run build-release
 
 ```
+
 Create a new github release and attach the generated tar file in the `build` directory to the github release.
 
-After the release is created the [publish](.github/workflows/publish.yml) action will automatically publish the release to npm.
-
-
-
+After the release is created the [publish](.github/workflows/publish.yml) action will automatically publish to npm.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Note that building isn't necessary for end-users and is more for developers look
 ```sh
     git clone git@github.com:IBM/nodejs-idb-connector.git
     cd nodejs-idb-connector
-    npm install --build-from-source
+    npm run build
 ```
 ## Build Dependencies
 Note: sqlcli header files, GCC, and Python are required to compile the code.
@@ -118,6 +118,22 @@ Note: sqlcli header files, GCC, and Python are required to compile the code.
     yum group install 'Development tools' 
     yum install python2
 ```
+
+## Release
+
+```sh
+   git clone git@github.com:IBM/nodejs-idb-connector.git
+   cd nodejs-idb-connector
+   npm install
+   npm run build-release
+
+```
+Create a new github release and attach the generated tar file in the `build` directory to the github release.
+
+After the release is created the [publish](.github/workflows/publish.yml) action will automatically publish the release to npm.
+
+
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "test": "ln -sf ./build-tmp-napi-v3 ./build && ./node_modules/mocha/bin/mocha.js --timeout 5s",
+    "test-node-versions": "nodever 12 && npm test test/dataTypes.js && nodever 14 && npm test test/dataTypes.js && nodever 16 && npm test test/dataTypes.js && nodever 18 && npm test test/dataTypes.js",
     "install": "node-pre-gyp install --fallback-to-build",
     "build": "npm install --build-from-source",
     "build-release": "./node_modules/.bin/node-pre-gyp rebuild --production && ./node_modules/.bin/node-pre-gyp package"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   },
   "scripts": {
     "test": "ln -sf ./build-tmp-napi-v3 ./build && ./node_modules/mocha/bin/mocha.js --timeout 5s",
-    "install": "node-pre-gyp install --fallback-to-build"
+    "install": "node-pre-gyp install --fallback-to-build",
+    "build": "npm install --build-from-source",
+    "build-release": "./node_modules/.bin/node-pre-gyp rebuild --production && ./node_modules/.bin/node-pre-gyp package"
   },
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.10",


### PR DESCRIPTION
- Add publish action derived from https://github.com/actions/starter-workflows/blob/9bca5754a6e9b132c49c1715085c747b21278dc9/ci/npm-publish.yml#L4
    Modified to skip  `npm ci` and running integration tests because this would fail on non IBM i systems.
- Document how to make a release
- Simplify the build and release commands by using npm scripts