### PR TITLE
fix: stop returning nulls

### DIFF
--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2491,9 +2491,6 @@ int DbStmt::buildJsObject(Napi::Env env, Napi::Array *array)
             break;
           }
         default:
-          if (resultSetInC[row][col].rlength > 0)
-            value = Napi::String::New(env, resultSetInC[row][col].data, resultSetInC[row][col].rlength);
-          else
             value = Napi::String::New(env, resultSetInC[row][col].data);
           break;
         }


### PR DESCRIPTION
When returning a result set from RPGLE External SQL Stored Procedure, nulls are being returned in the fields that are returned.

Documented recreating the customer issue in: https://github.com/IBM/nodejs-idb-connector/issues/169#issuecomment-1592214085

Documented Suggested code changes in: https://github.com/IBM/nodejs-idb-connector/issues/169#issuecomment-1592218433


Another possible solution would be to set  [SQL_ATTR_INCLUDE_NULL_IN_LEN](https://www.ibm.com/docs/en/i/7.3?topic=functions-sqlsetenvattr-set-environment-attribute) to `SQL_FALSE`


![image](https://github.com/IBM/nodejs-idb-connector/assets/33973272/e09261d8-b9b1-484d-8354-ca07ba199517)

I'm not sure how this would adversely affect the rest of the code base though. So for now reverting back to what we had before the changes in https://github.com/IBM/nodejs-idb-connector/commit/56d66e7faab1a8fd61ccb6971a3555723d8a63a5 (This added the rlength if condition) which seems to make the most sense at this time.

Fixes https://github.com/IBM/nodejs-idb-connector/issues/169